### PR TITLE
chore: add CI workflow (run tests + build on PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+# Run the test suite and build on every PR and on pushes to master so that
+# "tests pass" is verified by CI, not self-reported.
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    # Safety net: if Vitest ever engages watch mode despite --watch=false,
+    # fail fast instead of burning the 6-hour default job timeout.
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Repo pins no Node version (no engines/.nvmrc/volta), so use Node 20,
+          # matching the existing update-pmq-schedule workflow.
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        # ng test uses Angular's Vitest-backed unit-test builder, which defaults
+        # to watch mode in a TTY. --watch=false forces a single non-watch run so
+        # the job terminates instead of hanging.
+        run: npm test -- --watch=false
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## What

Adds `.github/workflows/ci.yml` — a GitHub Actions workflow that runs the test suite and build on every PR (and on pushes to `master`).

## Why

PRs currently have no CI: the test suite is never run automatically, so an agent's "tests pass" claim is unverified. This workflow makes test results verified by CI rather than self-reported.

## What it does

On `pull_request` and `push` to `master`:

1. `actions/checkout@v4`
2. `actions/setup-node@v4` — Node 20 (repo pins no Node version), npm cache
3. `npm ci`
4. `npm test -- --watch=false` — runs the Angular Vitest unit-test builder in **non-watch** mode so the job terminates instead of hanging
5. `npm run build` — production `ng build`

A `timeout-minutes: 15` guard fails the job fast if watch mode ever engages despite the flag.

Refs marvinbarretto/hub#36