### PR TITLE
fix: [App] repair the stale app.spec.ts scaffold test (breaks CI / whole suite red)

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { App } from './app';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 
@@ -14,10 +16,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', async () => {
+  it('should render a router-outlet', async () => {
     const fixture = TestBed.createComponent(App);
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, pmq-bingo');
+    expect(compiled.querySelector('router-outlet')).not.toBeNull();
   });
 });

--- a/src/app/components/bingo-cell/bingo-cell.spec.ts
+++ b/src/app/components/bingo-cell/bingo-cell.spec.ts
@@ -1,10 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRef } from '@angular/core';
 
 import { BingoCell } from './bingo-cell';
+import { BingoCell as BingoCellModel } from '../../models/game.model';
+
+const mockCell: BingoCellModel = {
+  phrase: { id: '1', text: 'Test phrase' },
+  marked: false,
+  position: 0,
+};
 
 describe('BingoCell', () => {
   let component: BingoCell;
   let fixture: ComponentFixture<BingoCell>;
+  let componentRef: ComponentRef<BingoCell>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -13,6 +22,8 @@ describe('BingoCell', () => {
     .compileComponents();
 
     fixture = TestBed.createComponent(BingoCell);
+    componentRef = fixture.componentRef;
+    componentRef.setInput('cell', mockCell);
     component = fixture.componentInstance;
     await fixture.whenStable();
   });


### PR DESCRIPTION
## Summary

The default Angular scaffold test in `app.spec.ts` asserted an `<h1>` containing "Hello, pmq-bingo", but the real `AppComponent` uses `template: '<router-outlet />'` with no heading. This made the entire test suite red, blocking all PRs since CI was added. Updated `app.spec.ts` to reflect the real component template.

Also fixed `bingo-cell.spec.ts` which had the same stale scaffold issue — it was missing the required `cell` input, causing `NG0950` errors and contributing to the suite being red.

## Changes

- `src/app/app.spec.ts` — removed stale scaffold assertion; added test verifying `<router-outlet>` renders
- `src/app/components/bingo-cell/bingo-cell.spec.ts` — provided required `cell` input via `componentRef.setInput()`

## Definition of Done Checklist

- [x] `app.spec.ts` no longer asserts non-existent `<h1>` / "Hello, pmq-bingo" — removed
- [x] Remaining tests reflect real component (renders `<router-outlet>`) — verified
- [x] `npm test -- --watch=false` passes green — 5 passed (4 test files)
- [x] No production code behaviour changed — only test files modified

## Screenshots

N/A — non-visual change: test fix

## Testing

`npm test -- --watch=false` output:
```
Test Files  4 passed (4)
Tests       5 passed (5)
Duration    945ms
```

## Notes

Test runner: Vitest via `ng test`. Only `src/app/app.spec.ts` and `src/app/components/bingo-cell/bingo-cell.spec.ts` were modified (both stale scaffold tests).

---
Dispatched by Jimbo · Task #2835 · Skill: code/pr-from-issue
Closes marvinbarretto/pmq-bingo#23